### PR TITLE
Fix bug in the `dynamics` caused (most likely) by the new package setup

### DIFF
--- a/src/modi_flows/dynamics.py
+++ b/src/modi_flows/dynamics.py
@@ -9,6 +9,7 @@ Contributors:
 import numpy as np
 from scipy.sparse import diags, identity, csr_matrix
 from scipy.sparse.linalg import spsolve
+import scipy.sparse as sp
 
 
 def ot_solve(self):
@@ -126,6 +127,8 @@ def ot_solve(self):
         it = 0
         # only needed if spsolve has problems
         prng = np.random.RandomState(seed=self.seed)
+
+        self.B = sp.csc_matrix(self.B) # to solve dimension mismatch errors
         stiff = self.B * diags(self.tdens, 0) * diags(1/self.length, 0) * self.B.transpose()
 
         # to increase if singularity issues arise in spsolve

--- a/src/modi_flows/main.py
+++ b/src/modi_flows/main.py
@@ -15,8 +15,11 @@ from skimage.color import rgb2gray
 from skimage.measure import block_reduce
 from scipy.ndimage import gaussian_filter
 
-from .initialization import *
-from .dynamics import *
+#from . import initialization as init
+#from . import dynamics as dyn
+
+import modi_flows.initialization as init
+import modi_flows.dynamics as dyn 
 
 # warn options
 if not sys.warnoptions:
@@ -64,8 +67,8 @@ class MODI:
             self.c, np.array: extended ground distance matrix, C
         """
 
-        ot_setup(self)
-        j = ot_solve(self)
+        init.ot_setup(self)
+        j = dyn.ot_solve(self)
 
         return j, self.r, self.s, self.c
 
@@ -79,7 +82,7 @@ class MODI:
             self.c, np.array: extended ground distance matrix, C
         """
 
-        ot_setup(self)
+        init.ot_setup(self)
 
         return self.r, self.s, self.c
 


### PR DESCRIPTION
It seems that for some reason, the matrix multiplication at the `dynamics` breaks because the incidence matrix `B` has a now different `scipy.sparse` type (`<class 'scipy.sparse._csc.csc_array'>`, when it should be `<class 'scipy.sparse._csc.csc_matrix'>`).  It is corrected now w.r.t to the new setup (just an extra line). 

I tested on the last version of the testpypi package and it works. :)