### PR TITLE
Fix `dashboard` imports

### DIFF
--- a/notebooks/dashboard.ipynb
+++ b/notebooks/dashboard.ipynb
@@ -16,7 +16,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 1,
    "id": "changed-girlfriend",
    "metadata": {},
    "outputs": [],
@@ -24,11 +24,8 @@
     "import nbimporter\n",
     "import utils\n",
     "\n",
-    "import sys\n",
-    "sys.path.append(\"..\")\n",
-    "\n",
-    "from src.main import MODI\n",
-    "from src.main import * # for transport network construction"
+    "from modi_flows.main import MODI\n",
+    "from modi_flows.main import * # for transport network construction"
    ]
   },
   {
@@ -49,7 +46,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 2,
    "id": "front-inclusion",
    "metadata": {},
    "outputs": [
@@ -57,7 +54,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 10/10 [00:00<00:00, 41.18it/s]\n"
+      "100%|████████████████████████████████████████████████████████████████| 10/10 [00:00<00:00, 31.34it/s]\n"
      ]
     }
    ],
@@ -222,7 +219,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 8,
    "id": "hired-satellite",
    "metadata": {},
    "outputs": [],
@@ -241,7 +238,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 9,
    "id": "distinct-cleaner",
    "metadata": {},
    "outputs": [],
@@ -260,7 +257,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 34,
    "id": "diverse-japan",
    "metadata": {},
    "outputs": [
@@ -294,7 +291,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 11,
    "id": "progressive-timeline",
    "metadata": {},
    "outputs": [],
@@ -308,7 +305,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 12,
    "id": "bibliographic-forestry",
    "metadata": {},
    "outputs": [],
@@ -360,6 +357,14 @@
    "source": [
     "utils.visualize_resuts(img1, img_list, lab1, lab_list, j_list)"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6fb3494f",
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {


### PR DESCRIPTION
Just changing the way the package is imported; local imports are no longer needed.